### PR TITLE
Don't ignore floating windows when cycling focus

### DIFF
--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -374,8 +374,8 @@ export class TilingEngine implements Engine {
     }
 
     const idx = visibles.indexOf(window);
-    if (!window || idx < 0) {
-      /* unmanaged window -> focus master */
+    if (!window) {
+      /* this probably shouldn't happen since we already checked for null */
       this.controller.currentWindow = visibles[0];
       return;
     }


### PR DESCRIPTION
closes #44

I have to test this still as I don't have time to mess with my setup.

In Krohnkite I just removed this whole `if` statement and haven't experienced any problems so far. Tenatively just left it like so (`if (!window){...}`) in case the null check at the beginning of the function misses something. Will do some testing when I get a chance and decide on an approach, then open this for review.