### PR TITLE
feat: :sparkles: add Krohnkite shortcuts import script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ KDE Plasma powered Linux distribution and enjoy your computing! 🦾
 
 ![script demo](img/demo.gif)
 
-This is a fork of [Krohnkite](https://github.com/esjeon/krohnkite). The fork was made, because the old project seems to be unmaintained.
+This is a fork of [Krohnkite](https://github.com/esjeon/krohnkite). The fork
+was made, because the old project seems to be unmaintained. If you want to
+import your old shortcuts from it, use the `contrib/import_krohnkite.sh`
+script.
 
 ## 🗺️ Goals
 

--- a/contrib/import_krohnkite.sh
+++ b/contrib/import_krohnkite.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2021 Mikhail Zolotukhin <mail@genda.life>
+#
+# SPDX-License-Identifier: MIT
+
+main ()
+{
+  # Declare a map of shortcuts keys
+  declare -A bis_to_kro
+  bis_to_kro["bismuth_decrease_master_size"]=""
+  bis_to_kro["bismuth_decrease_master_win_count"]="Krohnkite: Decrease"
+  bis_to_kro["bismuth_decrease_window_height"]="Krohnkite: Shrink Height"
+  bis_to_kro["bismuth_decrease_window_width"]="Krohnkite: Shrink Width"
+  bis_to_kro["bismuth_focus_bottom_window"]="Krohnkite: Down/Next"
+  bis_to_kro["bismuth_focus_left_window"]="Krohnkite: Left"
+  bis_to_kro["bismuth_focus_next_window"]=""
+  bis_to_kro["bismuth_focus_prev_window"]=""
+  bis_to_kro["bismuth_focus_right_window"]="Krohnkite: Right"
+  bis_to_kro["bismuth_focus_upper_window"]="Krohnkite: Up/Prev"
+  bis_to_kro["bismuth_increase_master_size"]=""
+  bis_to_kro["bismuth_increase_master_win_count"]="Krohnkite: Increase"
+  bis_to_kro["bismuth_increase_window_height"]="Krohnkite: Grow Height"
+  bis_to_kro["bismuth_increase_window_width"]="Krohnkite: Grow Width"
+  bis_to_kro["bismuth_move_window_to_bottom_pos"]="Krohnkite: Move Down/Next"
+  bis_to_kro["bismuth_move_window_to_left_pos"]="Krohnkite: Move Left"
+  bis_to_kro["bismuth_move_window_to_next_pos"]=""
+  bis_to_kro["bismuth_move_window_to_prev_pos"]=""
+  bis_to_kro["bismuth_move_window_to_right_pos"]="Krohnkite: Move Right"
+  bis_to_kro["bismuth_move_window_to_upper_pos"]="Krohnkite: Move Up/Prev"
+  bis_to_kro["bismuth_next_layout"]="Krohnkite: Next Layout"
+  bis_to_kro["bismuth_prev_layout"]="Krohnkite: Previous Layout"
+  bis_to_kro["bismuth_push_window_to_master"]="Krohnkite: Set master"
+  bis_to_kro["bismuth_rotate"]="Krohnkite: Rotate"
+  bis_to_kro["bismuth_rotate_part"]="Krohnkite: Rotate Part"
+  bis_to_kro["bismuth_toggle_monocle_layout"]="Krohnkite: Monocle Layout"
+  bis_to_kro["bismuth_toggle_quarter_layout"]="Krohnkite: Quarter Layout"
+  bis_to_kro["bismuth_toggle_spread_layout"]="Krohnkite: Spread Layout"
+  bis_to_kro["bismuth_toggle_stair_layout"]="Krohnkite: Stair Layout"
+  bis_to_kro["bismuth_toggle_three_column_layout"]="Krohnkite: Three Column Layout"
+  bis_to_kro["bismuth_toggle_tile_layout"]="Krohnkite: Tile"
+  bis_to_kro["bismuth_toggle_window_floating"]="Krohnkite: Float"
+  bis_to_kro["bismuth_toggle_floating_layout"]="Krohnkite: Float All"
+  
+  config_file_path=${1:-"~/.config/kglobalshortcutsrc"}
+
+  echo "Config file path: ${config_file_path}"
+  echo "Importing Krohnkite shortcuts..."
+
+  # Iterate over each pair and move the Krohnkite shortcut to Bismuth one
+  for key in "${!bis_to_kro[@]}"; do
+    bis_key="${key}"
+    kro_key=${bis_to_kro[$key]}
+    bis_val=$(kreadconfig5 --file "${config_file_path}" --group "kwin" --key "${bis_key}")
+    kro_val=$(kreadconfig5 --file "${config_file_path}" --group "kwin" --key "${kro_key}")
+
+    IFS=',' read -ra bis_val_arr <<< "$bis_val"
+    IFS=',' read -ra kro_val_arr <<< "$kro_val"
+    
+    bis_primary_shortcut="${bis_val_arr[0]}"
+    bis_secondary_shortcut="${bis_val_arr[1]}"
+    bis_description="${bis_val_arr[2]}"
+
+    kro_primary_shortcut="${kro_val_arr[0]}"
+    kro_secondary_shortcut="${kro_val_arr[1]}"
+    kro_description="${kro_val_arr[2]}"
+
+    kwriteconfig5 --file "${config_file_path}" --group "kwin" --key "${kro_key}" --delete > /dev/null 2>&1
+    kwriteconfig5 --file "${config_file_path}" --group "kwin" --key "${bis_key}" "${kro_primary_shortcut:-none},${kro_secondary_shortcut:-none},${bis_description}"
+  done
+
+  # Reload shortcuts configuration
+  qdbus org.kde.keyboard /modules/khotkeys reread_configuration
+}
+
+main $1


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

This change adds a bash script, that moves the old Krohnkite shortcuts to Bismuth ones (i.e. imports them).
  
## Test Plan

1. Copy the shortcuts' configuration from "~/.config/kglobalshortcutsrc" to a file. The file must contain definitions for both Krohnkite and Bismuth
2. Execute the new script with the absolute path to this script: `contrib/import_krohnkite.sh $PWD/shortcuts_test_file`
3. Shortcuts from Krohnkite should be deleted and the bismuth ones should contain the definitions from previous Krohnkite shortcuts.
4. Given that the Bismuth script was already running, you should be able to use new shortcuts.

## Related Issues

Closes #26 
