### PR TITLE
ci: 👷 publish artifacts on release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,9 +11,30 @@ on:
 
 jobs:
   release-please:
+    name: Release Please
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - name: Release Please 🔖
+        uses: GoogleCloudPlatform/release-please-action@v2
+        id: release
         with:
           release-type: node
           package-name: release-please-action
+
+      - uses: actions/checkout@v2
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Package 📦
+        run: |
+          npm install
+          npm run package
+        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Publish 🎉
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.release.outputs.tag_name }}
+          files: |
+            build/package/bismuth.tar.gz
+            build/package/bismuth.kwinscript
+        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

This modifies release please workflow, so that the packages (kwinscript and the quick-install archive) will be published, when a new release is created.

## Test Plan

Tested on https://github.com/gikari/test-bismuth-ci

## Related Issues

Ref #1
