### PR TITLE
fix: :bug: correctly import Tile Layout Krohnkite shortcut

### DIFF
--- a/contrib/import_krohnkite.sh
+++ b/contrib/import_krohnkite.sh
@@ -38,7 +38,7 @@ main ()
   bis_to_kro["bismuth_toggle_spread_layout"]="Krohnkite: Spread Layout"
   bis_to_kro["bismuth_toggle_stair_layout"]="Krohnkite: Stair Layout"
   bis_to_kro["bismuth_toggle_three_column_layout"]="Krohnkite: Three Column Layout"
-  bis_to_kro["bismuth_toggle_tile_layout"]="Krohnkite: Tile"
+  bis_to_kro["bismuth_toggle_tile_layout"]="Krohnkite: Tile Layout"
   bis_to_kro["bismuth_toggle_window_floating"]="Krohnkite: Float"
   bis_to_kro["bismuth_toggle_floating_layout"]="Krohnkite: Float All"
   


### PR DESCRIPTION
<!-- This won't be rendered!
[CHECKLIST]
- I read the contributing guide (CONTRIBUTING.md)
- My code follows the style guidelines of this project
- I have performed a self-review of my code
- I have commented on my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
-->

## Summary

Use correct key from the old configuration.

## Test Plan

1. Run contrib/imprort_krohnkite.sh
2. Tile layout shortcut should be imported

## Related Issues

Ref #90 
